### PR TITLE
Support to stream responses

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,26 +2,61 @@
 
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:ff6b0586c0621a76832cf783eee58cbb9d9795d2ce8acbc199a4131db11c42a9"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
 
 [[projects]]
   branch = "master"
+  digest = "1:08e00568d99ec12096ba60887632eb2b94ed8b3c23e2ed90eb263e12eacf8f3a"
   name = "github.com/streadway/amqp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e5adc2ada8b8efff032bf61173a233d143e9318e"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
+[[projects]]
+  digest = "1:35171288ba556e36ae2accaa41516dfcc58cc8c5a66a00cfeae4fed4bc1dfef7"
   name = "gopkg.in/go-playground/assert.v1"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4f4dfbc7d1c48336cf93399deae81aa9067e88af"
   version = "v1.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ea43dbf63e6cc9cb6c44a748d45ae08ddfed59ff15672ee14931b2a73039ed5"
+  input-imports = [
+    "github.com/satori/go.uuid",
+    "github.com/streadway/amqp",
+    "github.com/stretchr/testify/assert",
+    "gopkg.in/go-playground/assert.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
This is my idea of how to solve #50. I'm not sure I'm 100% satisfied with how errors are handled (not at all) and how the cleanup is made, however I don't see any risk of enforcing the end user to clean up the correlation ID mapping by explicitly calling `EndStream()`.

TODO: Update README.