### PR TITLE
Add Makefile, add git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,38 @@ DOCKER_COMPOSE      = docker-compose
 GOLANGCI_VERSION    = v1.21.0
 GOPATH              = $(shell go env GOPATH)
 
-all: lint test
+all: lint test ## Run linting and testing
 
-compose:
+# Use `-run==` to support Windows where ^ is an escape sequence and no test can
+# ever start with literal `=`.
+bench: ## Run benchmarks only
+	go test ./... -bench=. -run== -v
+
+compose: ## Start the docker-compose environment
 	$(DOCKER_COMPOSE) up -d
 
-compose-down:
+compose-down: ## Stop the docker-compose environment
 	$(DOCKER_COMPOSE) down
 
-$(GOPATH)/bin/golangci-lint:
+$(GOPATH)/bin/golangci-lint: ## Ensure golangci-lint is installed
 	$(CURL) -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
 
-hooks:
+# This will grep the double comment marker (##) and map all targets to the
+# comment which will just print the comment next to each target for documenting
+# purposes.
+help: ## Show this help text
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "}; \
+		{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+hooks: ## Install tracked git hooks
 	script/install-hooks
 
-lint: $(GOPATH)/bin/golangci-lint
+lint: $(GOPATH)/bin/golangci-lint ## Lint the code
 	$(GOPATH)/bin/golangci-lint run ./...
 
-test: compose
-	go test ./...
+test: compose ## Run all tests (with race detection)
+	go test ./... -race -v
 
-.PHONY: all compose compose-down hooks lint test
+.PHONY: all compose compose-down help hooks lint test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CURL               ?= curl
+DOCKER_COMPOSE      = docker-compose
+GOLANGCI_VERSION    = v1.21.0
+GOPATH              = $(shell go env GOPATH)
+
+all: lint test
+
+compose:
+	$(DOCKER_COMPOSE) up -d
+
+compose-down:
+	$(DOCKER_COMPOSE) down
+
+$(GOPATH)/bin/golangci-lint:
+	$(CURL) -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
+
+hooks:
+	script/install-hooks
+
+lint: $(GOPATH)/bin/golangci-lint
+	$(GOPATH)/bin/golangci-lint run ./...
+
+test: compose
+	go test ./...
+
+.PHONY: all compose compose-down hooks lint test

--- a/script/hooks-wrapper
+++ b/script/hooks-wrapper
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+HOOK_NAME="$0"
+HOOK_PATH_LOCAL="$HOOK_NAME.local"
+HOOK_PATH="$(basename "$HOOK_NAME")"
+
+# Execute passed command with all passed arguments, exit with exit status 1 if
+# not executed successful.
+exec_and_maybe_exit() {
+    SCRIPT_NAME="$1"
+
+    if ! "$SCRIPT_NAME" "$@"; then
+        echo "⚠️  Failed to execute '$SCRIPT_NAME'"
+        exit 1
+    fi
+}
+
+# If a `local` suffixed version of the script exist, execut it first.
+if [ -x "$HOOK_PATH_LOCAL" ]; then
+    exec_and_maybe_exit "script/$HOOK_PATH_LOCAL" "$@"
+fi
+
+# If a symlinked version also exists execute that.
+if [ -x "script/$HOOK_PATH" ]; then
+    exec_and_maybe_exit "script/$HOOK_PATH" "$@"
+fi

--- a/script/install-hooks
+++ b/script/install-hooks
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# All known hooks that might be symlinked.
+HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch \
+    pre-commit prepare-commit-msg commit-msg post-commit \
+    pre-rebase post-checkout post-merge pre-receive update \
+    post-receive post-update pre-auto-gc"
+
+# Get locations of project hooks.
+HOOK_DIR=$(git rev-parse --show-toplevel)/.git/hooks
+
+for hook in $HOOK_NAMES; do
+    # If a hook with the same name exists and is executable but not a symlink,
+    # back it up with the suffix `local`.
+    if [ ! -h "$HOOK_DIR/$hook" ] && [ -x "$HOOK_DIR/$hook" ]; then
+        mv "$HOOK_DIR/$hook" "$HOOK_DIR/$hook.local"
+    fi
+
+    # Create symlink, overwriting the file if it exists probably the only way
+    # this would happen is if you're using an old version of git -- back when
+    # the sample hooks were not executable, instead of being named ____.sample
+    ln -s -f ../../script/hooks-wrapper "$HOOK_DIR/$hook"
+done

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make lint


### PR DESCRIPTION
To avoid missing failing tests or linter errors before pushing I added a `Makefile` for easier testing and also added a solution to share git hooks.

Install hooks with `make hooks`. It will backup potential existing hooks in the project and symlink the ones tracked in this project. Each hook is symlinked to a wrapper calling both the local and the bundled hook to allow users to keep using their personal hooks.

The only hook added now is `pre-commit` which will lint. I'm open to add `make test` too even though it requires a local running compose environment.