### PR TITLE
Add `OnErrFunc` which is more generic in how ack failures are handled

### DIFF
--- a/middleware/ack.go
+++ b/middleware/ack.go
@@ -2,16 +2,23 @@ package middleware
 
 import (
 	"context"
+	"log"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
 	amqprpc "github.com/0x4b53/amqp-rpc/v3"
 )
 
+type OnErrFunc func(err error, correlationID string)
+
+func AckLogError(err error, correlationID string) {
+	log.Printf("could not ack delivery (%s): %v\n", correlationID, err)
+}
+
 // AckDelivery is a middleware that will acknowledge the delivery after the
 // handler has been executed. Any error returned from d.Ack will be passed
 // to the provided logFunc.
-func AckDelivery(logFunc amqprpc.LogFunc) amqprpc.ServerMiddlewareFunc {
+func AckDelivery(onErrFn OnErrFunc) amqprpc.ServerMiddlewareFunc {
 	return func(next amqprpc.HandlerFunc) amqprpc.HandlerFunc {
 		return func(ctx context.Context, rw *amqprpc.ResponseWriter, d amqp.Delivery) {
 			acknowledger := amqprpc.NewAwareAcknowledger(d.Acknowledger)
@@ -23,9 +30,8 @@ func AckDelivery(logFunc amqprpc.LogFunc) amqprpc.ServerMiddlewareFunc {
 				return
 			}
 
-			err := d.Ack(false)
-			if err != nil {
-				logFunc("could not Ack delivery (%s): %v", d.CorrelationId, err)
+			if err := d.Ack(false); err != nil {
+				onErrFn(err, d.CorrelationId)
 			}
 		}
 	}

--- a/middleware/ack.go
+++ b/middleware/ack.go
@@ -2,11 +2,9 @@ package middleware
 
 import (
 	"context"
-	"log"
-
-	amqp "github.com/rabbitmq/amqp091-go"
 
 	amqprpc "github.com/0x4b53/amqp-rpc/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // OnErrFunc is the function that will be called when the middleware get an
@@ -17,9 +15,11 @@ type OnErrFunc func(err error, correlationID string)
 // AckLogError is a built-in function that will log the error if any is returned
 // from `Ack`.
 //
-//	middleware := AckDelivery(AckLogError)
-func AckLogError(err error, correlationID string) {
-	log.Printf("could not ack delivery (%s): %v\n", correlationID, err)
+//	middleware := AckDelivery(AckLogError(log.Printf))
+func AckLogError(logFn amqprpc.LogFunc) OnErrFunc {
+	return func(err error, correlationID string) {
+		logFn("could not ack delivery (%s): %v\n", correlationID, err)
+	}
 }
 
 // AckDelivery is a middleware that will acknowledge the delivery after the

--- a/middleware/ack.go
+++ b/middleware/ack.go
@@ -9,8 +9,15 @@ import (
 	amqprpc "github.com/0x4b53/amqp-rpc/v3"
 )
 
+// OnErrFunc is the function that will be called when the middleware get an
+// error from `Ack`. The error and the correlation ID for the delivery will be
+// passed.
 type OnErrFunc func(err error, correlationID string)
 
+// AckLogError is a built-in function that will log the error if any is returned
+// from `Ack`.
+//
+//	middleware := AckDelivery(AckLogError)
 func AckLogError(err error, correlationID string) {
 	log.Printf("could not ack delivery (%s): %v\n", correlationID, err)
 }

--- a/middleware/ack.go
+++ b/middleware/ack.go
@@ -11,22 +11,22 @@ import (
 // error from `Ack`. The error and the delivery will be passed.
 type OnErrFunc func(err error, delivery amqp.Delivery)
 
-// OnErrLogError is a built-in function that will log the error if any is
+// OnAckErrorLog is a built-in function that will log the error if any is
 // returned from `Ack`.
 //
-//	middleware := AckDelivery(OnErrLogError(log.Printf))
-func OnErrLogError(logFn amqprpc.LogFunc) OnErrFunc {
+//	middleware := AckDelivery(OnAckErrorLog(log.Printf))
+func OnAckErrorLog(logFn amqprpc.LogFunc) OnErrFunc {
 	return func(err error, delivery amqp.Delivery) {
 		logFn("could not ack delivery (%s): %v\n", delivery.CorrelationId, err)
 	}
 }
 
-// OnErrSendOnChannel will first log the error and correlation ID and then try
-// to send on the passed channel. If no one is consuming on the passed channel
-// the middleware will not block but instead log a message about missing channel
-// consumers.
-func OnErrSendOnChannel(logFn amqprpc.LogFunc, ch chan struct{}) OnErrFunc {
-	logErr := OnErrLogError(logFn)
+// OnAckErrorSendOnChannel will first log the error and correlation ID and then
+// try to send on the passed channel. If no one is consuming on the passed
+// channel the middleware will not block but instead log a message about missing
+// channel consumers.
+func OnAckErrorSendOnChannel(logFn amqprpc.LogFunc, ch chan struct{}) OnErrFunc {
+	logErr := OnAckErrorLog(logFn)
 
 	return func(err error, delivery amqp.Delivery) {
 		logErr(err, delivery)
@@ -40,8 +40,8 @@ func OnErrSendOnChannel(logFn amqprpc.LogFunc, ch chan struct{}) OnErrFunc {
 }
 
 // AckDelivery is a middleware that will acknowledge the delivery after the
-// handler has been executed. Any error returned from d.Ack will be passed
-// to the provided logFunc.
+// handler has been executed. If the Ack fails the error and the `amqp.Delivery`
+// will be passed to the `OnErrFunc`.
 func AckDelivery(onErrFn OnErrFunc) amqprpc.ServerMiddlewareFunc {
 	return func(next amqprpc.HandlerFunc) amqprpc.HandlerFunc {
 		return func(ctx context.Context, rw *amqprpc.ResponseWriter, d amqp.Delivery) {

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -2,8 +2,11 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"log"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
@@ -13,32 +16,66 @@ import (
 
 func TestAckDelivery(t *testing.T) {
 	tests := []struct {
-		handler amqprpc.HandlerFunc
-		name    string
+		handler          amqprpc.HandlerFunc
+		name             string
+		ackReturn        error
+		didSendOnChannel bool
 	}{
 		{
-			name:    "handler doesn't ack",
-			handler: func(_ context.Context, _ *amqprpc.ResponseWriter, _ amqp.Delivery) {},
+			name:      "handler doesn't ack",
+			handler:   func(_ context.Context, _ *amqprpc.ResponseWriter, _ amqp.Delivery) {},
+			ackReturn: nil,
 		},
 		{
 			name: "handler does ack",
 			handler: func(_ context.Context, _ *amqprpc.ResponseWriter, d amqp.Delivery) {
 				_ = d.Ack(false)
 			},
+			ackReturn: nil,
+		},
+		{
+			name:             "handler fails to ack",
+			handler:          func(_ context.Context, _ *amqprpc.ResponseWriter, _ amqp.Delivery) {},
+			ackReturn:        errors.New("issue in the multiplexer"), //nolint:err113 // Just a test
+			didSendOnChannel: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			acknowledger := &amqprpc.MockAcknowledger{}
+			acknowledger := &amqprpc.MockAcknowledger{
+				OnAckFn: func() error {
+					return tt.ackReturn
+				},
+			}
 
-			handler := AckDelivery(AckLogError(log.Printf))(tt.handler)
+			didSendOnCh := atomic.Bool{}
+			didSendOnCh.Store(false)
+
+			// We setup a channel to ensure we don't proceed until we started
+			// the go routine that will listen to the signal.
+			isListening := make(chan struct{})
+
+			ch := make(chan struct{})
+			go func() {
+				close(isListening)
+				<-ch
+				didSendOnCh.Store(true)
+			}()
+
+			// Block until ready.
+			<-isListening
+
+			handler := AckDelivery(AckSendOnChannel(log.Printf, ch))(tt.handler)
 
 			rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
-			d := amqp.Delivery{Acknowledger: acknowledger}
+			d := amqp.Delivery{Acknowledger: acknowledger, CorrelationId: "id-1234"}
 
 			handler(context.Background(), rw, d)
 
 			assert.Equal(t, 1, acknowledger.Acks)
+			assert.Eventually(t, func() bool {
+				return didSendOnCh.Load() == tt.didSendOnChannel
+			}, 2*time.Second, 100*time.Millisecond)
 		})
 	}
 }

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"log"
 	"testing"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -31,7 +30,7 @@ func TestAckDelivery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			acknowledger := &amqprpc.MockAcknowledger{}
 
-			handler := AckDelivery(log.Printf)(tt.handler)
+			handler := AckDelivery(func(_ error, _ string) {})(tt.handler)
 
 			rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
 			d := amqp.Delivery{Acknowledger: acknowledger}

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -65,7 +65,7 @@ func TestAckDelivery(t *testing.T) {
 			// Block until ready.
 			<-isListening
 
-			handler := AckDelivery(AckSendOnChannel(log.Printf, ch))(tt.handler)
+			handler := AckDelivery(OnErrSendOnChannel(log.Printf, ch))(tt.handler)
 
 			rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
 			d := amqp.Delivery{Acknowledger: acknowledger, CorrelationId: "id-1234"}

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -65,7 +65,7 @@ func TestAckDelivery(t *testing.T) {
 			// Block until ready.
 			<-isListening
 
-			handler := AckDelivery(OnErrSendOnChannel(log.Printf, ch))(tt.handler)
+			handler := AckDelivery(OnAckErrorSendOnChannel(log.Printf, ch))(tt.handler)
 
 			rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
 			d := amqp.Delivery{Acknowledger: acknowledger, CorrelationId: "id-1234"}

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"log"
 	"testing"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -30,7 +31,7 @@ func TestAckDelivery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			acknowledger := &amqprpc.MockAcknowledger{}
 
-			handler := AckDelivery(func(_ error, _ string) {})(tt.handler)
+			handler := AckDelivery(AckLogError(log.Printf))(tt.handler)
 
 			rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
 			d := amqp.Delivery{Acknowledger: acknowledger}

--- a/testing.go
+++ b/testing.go
@@ -25,11 +25,17 @@ type MockAcknowledger struct {
 	Acks    int
 	Nacks   int
 	Rejects int
+	OnAckFn func() error
 }
 
 // Ack increases Acks.
 func (ma *MockAcknowledger) Ack(_ uint64, _ bool) error {
 	ma.Acks++
+
+	if ma.OnAckFn != nil {
+		return ma.OnAckFn()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This will make it possible to take more granular actions on ack failures.

---

Related to #107. This will make it easier to take custom action when acking fails.