### PR TITLE
Add support to simpler restart server by using a restart channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -395,7 +395,8 @@ func (c *Client) runOnce() error {
 
 	go c.runPublisher(outputCh)
 
-	err = monitorAndWait(
+	_, err = monitorAndWait(
+		make(chan struct{}),
 		c.stopChan,
 		inputConn.NotifyClose(make(chan *amqp.Error)),
 		outputConn.NotifyClose(make(chan *amqp.Error)),

--- a/server.go
+++ b/server.go
@@ -303,7 +303,7 @@ func (s *Server) listenAndServe() (bool, error) {
 	// -- https://godoc.org/github.com/rabbitmq/amqp091-go#Channel.Consume
 	inputConn, outputConn, err := createConnections(s.url, s.dialconfig)
 	if err != nil {
-		return true, err
+		return false, err
 	}
 
 	defer inputConn.Close()
@@ -311,7 +311,7 @@ func (s *Server) listenAndServe() (bool, error) {
 
 	inputCh, outputCh, err := createChannels(inputConn, outputConn)
 	if err != nil {
-		return true, err
+		return false, err
 	}
 
 	defer inputCh.Close()
@@ -323,7 +323,7 @@ func (s *Server) listenAndServe() (bool, error) {
 		false,
 	)
 	if err != nil {
-		return true, err
+		return false, err
 	}
 
 	// Notify everyone that the server has started.
@@ -338,7 +338,7 @@ func (s *Server) listenAndServe() (bool, error) {
 	// cancel our consumers.
 	consumerTags, err := s.startConsumers(inputCh, &consumersWg)
 	if err != nil {
-		return true, err
+		return false, err
 	}
 
 	// This WaitGroup will reach 0 when the responder() has finished sending

--- a/server_test.go
+++ b/server_test.go
@@ -185,6 +185,10 @@ func TestManualRestart(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("Hello"), reply.Body)
 
+	// We only care about one restart but let's call multiple ones to ensure
+	// we're not blocking.
+	s.Restart()
+	s.Restart()
 	s.Restart()
 	<-hasStarted
 

--- a/server_test.go
+++ b/server_test.go
@@ -165,8 +165,9 @@ func TestManualRestart(t *testing.T) {
 		hasStarted <- struct{}{}
 	})
 
-	s.Bind(DirectBinding("myqueue", func(ctx context.Context, rw *ResponseWriter, d amqp.Delivery) {
+	s.Bind(DirectBinding("myqueue", func(_ context.Context, rw *ResponseWriter, d amqp.Delivery) {
 		_ = d.Ack(false)
+
 		fmt.Fprintf(rw, "Hello")
 	}))
 
@@ -184,8 +185,7 @@ func TestManualRestart(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("Hello"), reply.Body)
 
-	// Retart the server and don't send the new message until we're restarted.
-	restartChan <- struct{}{}
+	s.Restart()
 	<-hasStarted
 
 	request = NewRequest().WithRoutingKey("myqueue")


### PR DESCRIPTION
This will add support to keep a restart channel on the server that can be triggered (send a `struct{}{}` or close) to restart the server. By doing this the user can trigger a graceful restart when needed without having to break out of the `ListenAndServe` loop.

---

Related to #107 and #108. This will introduce a new channel that can trigger server restarts without breaking out of `ListenAndServe`.