### PR TITLE
Context & Response

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -30,27 +30,36 @@ func monitorAndWait(
 	select {
 	case <-restartChan:
 		return true, nil
+
 	case <-stopChan:
 		return false, nil
+
 	case err, ok := <-inputConnClose:
 		if !ok {
 			return false, ErrUnexpectedConnClosed
 		}
+
 		return false, err
+
 	case err, ok := <-outputConnClose:
 		if !ok {
 			return false, ErrUnexpectedConnClosed
 		}
+
 		return false, err
+
 	case err, ok := <-inputChClose:
 		if !ok {
 			return false, ErrUnexpectedConnClosed
 		}
+
 		return false, err
+
 	case err, ok := <-outputChClose:
 		if !ok {
 			return false, ErrUnexpectedConnClosed
 		}
+
 		return false, err
 	}
 }

--- a/logging.go
+++ b/logging.go
@@ -185,8 +185,10 @@ func slogAttrsForRequest(v *Request) []slog.Attr {
 		vals = append(vals, slog.Bool("mandatory", v.Mandatory))
 	}
 
-	if v.Timeout > 0 {
-		vals = append(vals, slog.Duration("timeout", v.Timeout))
+	if v.Context != nil {
+		if deadline, ok := v.Context.Deadline(); ok {
+			vals = append(vals, slog.Time("deadline", deadline))
+		}
 	}
 
 	return vals

--- a/request.go
+++ b/request.go
@@ -46,16 +46,14 @@ type Request struct {
 
 	// These channels are used by the repliesConsumer and correlcationIdMapping and will send the
 	// replies to this Request here.
-	response chan *amqp.Delivery
-	errChan  chan error // If we get a client error (e.g we can't publish) it will end up here.
+	response chan response
 
 	// the number of times that the publisher should retry.
 	numRetries int
 
 	deliveryTag uint64
 
-	confirmed chan struct{}
-	returned  *amqp.Return
+	returned *amqp.Return
 }
 
 // NewRequest will generate a new request to be published. The default request
@@ -256,4 +254,9 @@ func (m *RequestMap) Delete(r *Request) {
 	delete(m.byDeliveryTag, r.deliveryTag)
 	delete(m.byCorrelationID, r.Publishing.CorrelationId)
 	m.mu.Unlock()
+}
+
+type response struct {
+	delivery *amqp.Delivery
+	err      error
 }


### PR DESCRIPTION
- Uses proper context deadline and cancellation so that a context cancel will stop stop waiting for responses.
- Simplifies response handling by using `context.Done()` and merging error and response chan on the request.
- Fixes a bug where a connection or channel would close before `monitorAndWait` was properly setup.