### PR TITLE
Refactor OnStarted & Client.runForever

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,18 +374,18 @@ For more examples of client middlewares, see [examples/middleware].
 ## Connection hooks
 
 You often want to know when a connection has been established and when it comes
-to RabbitMQ also perform some post connection setup. This is enabled by the fact
-that both the server and the client holds a list of `OnStarted`. The function
-receives the incoming connection, outgoing connection, incoming channel and
-outgoing channel.
+to RabbitMQ also perform some post connection setup. This is enabled by the
+fact that both the server and the client holds a list of `OnConnectedFunc`. The
+function receives the incoming connection, outgoing connection, incoming
+channel and outgoing channel.
 
 ```go
-type OnStartedFunc func(inputConn, outputConn *amqp.Connection, inputChannel, outputChannel *amqp.Channel)
+type OnConnectedFunc func(inputConn, outputConn *amqp.Connection, inputChannel, outputChannel *amqp.Channel)
 ```
 
 ```go
 server := NewServer("amqp://guest:guest@localhost:5672").
-    OnStarted(func(inConn, outConn *amqp.Connection, inChan, outChan *amqp.Channel) {
+    OnConnected(func(inConn, outConn *amqp.Connection, inChan, outChan *amqp.Channel) {
         // Do something after connection here...
     })
 }

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -92,7 +92,7 @@ func TestSkipQueueDeclare(t *testing.T) {
 			WithQueueDeclareArg("x-expires", 33),
 	)
 
-	stop = startAndWait(s)
+	stop = startServerAndWait(s)
 	defer stop()
 
 	response, err = c.Send(NewRequest().WithRoutingKey(queueName))

--- a/connection.go
+++ b/connection.go
@@ -13,11 +13,11 @@ import (
 // when said shutdown happens.
 var ErrUnexpectedConnClosed = errors.New("unexpected connection close without specific error")
 
-// OnStartedFunc can be registered at Server.OnStarted(f) and
-// Client.OnStarted(f). This is used when you want to do more setup on the
+// OnConnectedFunc can be registered with [Server.OnConnected] and
+// [Client.OnConnected]. This is used when you want to do more setup on the
 // connections and/or channels from amqp, for example setting Qos,
 // NotifyPublish etc.
-type OnStartedFunc func(inputConn, outputConn *amqp.Connection, inputChannel, outputChannel *amqp.Channel)
+type OnConnectedFunc func(inputConn, outputConn *amqp.Connection, inputChannel, outputChannel *amqp.Channel)
 
 func monitorAndWait(
 	restartChan,

--- a/logging_test.go
+++ b/logging_test.go
@@ -23,7 +23,7 @@ func TestServerLogging(t *testing.T) {
 		s := NewServer(testURL).
 			WithLogger(logger)
 
-		stop := startAndWait(s)
+		stop := startServerAndWait(s)
 		stop()
 
 		assert.NoError(t, writer.Close())

--- a/request_test.go
+++ b/request_test.go
@@ -20,7 +20,7 @@ func TestRequest(t *testing.T) {
 		fmt.Fprintf(rw, "Got message: %s", d.Body)
 	}))
 
-	stop := startAndWait(s)
+	stop := startServerAndWait(s)
 	defer stop()
 
 	client := NewClient(url)


### PR DESCRIPTION
Using the public `Connect` together with the delayed `OnConnect` enables the user to pre-start the client and even wait for proper binding setup before continuing if needed. Just like we do in the tests in this PR. Making the Connect function public also helps the user to to avoid a higher latency during the first call to Send().

Previously the `OnConnect` (previously `OnStarted`) callbacks where ran before any consumers or
bindings where created making the feature less useful. Now we can use it
to know when the server has finished binding to all queues or when the
`reply_to` queue for the client is actually created etc.

Refactoring the names of `OnConnected` and `Connect` makes more sense.


