### PR TITLE
Handle errors when acking messages

### DIFF
--- a/acknowledger.go
+++ b/acknowledger.go
@@ -1,37 +1,136 @@
 package amqprpc
 
 import (
+	"context"
+	"errors"
+	"log/slog"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-// AwareAcknowledger implements the amqp.Acknowledger interface with the
-// addition that it can tell if a message has been acked in any way.
-type AwareAcknowledger struct {
+// SafeAcknowledgeHandler implements the amqp.Acknowledger interface with the
+// addition that it can tell if a message has been acked in any way, and
+// if the ack action fails - it will close the underlying connection.
+type SafeAcknowledgeHandler struct {
 	Acknowledger amqp.Acknowledger
 	Handled      bool
+	conn         *amqp.Channel
 }
 
-// NewAwareAcknowledger returns the passed acknowledger as an AwareAcknowledger.
-func NewAwareAcknowledger(acknowledger amqp.Acknowledger) *AwareAcknowledger {
-	return &AwareAcknowledger{
+// NewSafeAcknowledgeHandler returns the passed acknowledger as an AwareAcknowledger.
+func NewSafeAcknowledgeHandler(acknowledger amqp.Acknowledger, ch *amqp.Channel) *SafeAcknowledgeHandler {
+	return &SafeAcknowledgeHandler{
 		Acknowledger: acknowledger,
+		conn:         ch,
 	}
 }
 
 // Ack passes the Ack down to the underlying Acknowledger.
-func (a *AwareAcknowledger) Ack(tag uint64, multiple bool) error {
+// Will close the underlying connection if ack fails.
+func (a *SafeAcknowledgeHandler) Ack(tag uint64, multiple bool) error {
+	if a.Handled {
+		return nil
+	}
+
 	a.Handled = true
-	return a.Acknowledger.Ack(tag, multiple)
+
+	err := a.Acknowledger.Ack(tag, multiple)
+	if err == nil {
+		return nil
+	}
+
+	slog.WarnContext(
+		context.Background(),
+		"error when acking",
+		"error",
+		err,
+	)
+
+	err = a.closeConnection()
+	if err != nil {
+		slog.ErrorContext(
+			context.Background(),
+			"could not close underlying connection",
+			"error",
+			err,
+		)
+	}
+
+	return err
 }
 
 // Nack passes the Nack down to the underlying Acknowledger.
-func (a *AwareAcknowledger) Nack(tag uint64, multiple, requeue bool) error {
+// Will close the underlying connection if nack fails.
+func (a *SafeAcknowledgeHandler) Nack(tag uint64, multiple, requeue bool) error {
+	if a.Handled {
+		return nil
+	}
+
 	a.Handled = true
-	return a.Acknowledger.Nack(tag, multiple, requeue)
+
+	err := a.Acknowledger.Nack(tag, multiple, requeue)
+	if err == nil {
+		return nil
+	}
+
+	slog.WarnContext(
+		context.Background(),
+		"error when nacking",
+		"error",
+		err,
+	)
+
+	err = a.closeConnection()
+	if err != nil {
+		slog.ErrorContext(
+			context.Background(),
+			"could not close underlying connection",
+			"error",
+			err,
+		)
+	}
+
+	return err
 }
 
 // Reject passes the Reject down to the underlying Acknowledger.
-func (a *AwareAcknowledger) Reject(tag uint64, requeue bool) error {
+// Will close the underlying connection if rejection fails.
+func (a *SafeAcknowledgeHandler) Reject(tag uint64, requeue bool) error {
+	if a.Handled {
+		return nil
+	}
+
 	a.Handled = true
-	return a.Acknowledger.Reject(tag, requeue)
+
+	err := a.Acknowledger.Reject(tag, requeue)
+	if err == nil {
+		return nil
+	}
+
+	slog.WarnContext(
+		context.Background(),
+		"error when rejecting",
+		"error",
+		err,
+	)
+
+	err = a.closeConnection()
+	if err != nil {
+		slog.ErrorContext(
+			context.Background(),
+			"could not close underlying connection",
+			"error",
+			err,
+		)
+	}
+
+	return err
+}
+
+func (a *SafeAcknowledgeHandler) closeConnection() error {
+	if a.conn == nil {
+		return errors.New("can't stop connection - no underlying connection set")
+	}
+
+	return a.conn.Close()
 }

--- a/acknowledger.go
+++ b/acknowledger.go
@@ -1,136 +1,82 @@
 package amqprpc
 
 import (
-	"context"
 	"errors"
-	"log/slog"
+	"sync/atomic"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-// SafeAcknowledgeHandler implements the amqp.Acknowledger interface with the
-// addition that it can tell if a message has been acked in any way, and
-// if the ack action fails - it will close the underlying connection.
-type SafeAcknowledgeHandler struct {
-	Acknowledger amqp.Acknowledger
-	Handled      bool
-	conn         *amqp.Channel
+type closer interface {
+	Close() error
 }
 
-// NewSafeAcknowledgeHandler returns the passed acknowledger as an AwareAcknowledger.
-func NewSafeAcknowledgeHandler(acknowledger amqp.Acknowledger, ch *amqp.Channel) *SafeAcknowledgeHandler {
-	return &SafeAcknowledgeHandler{
+// Acknowledger implements the amqp.Acknowledger interface with the
+// addition that it can tell if a message has been acked in any way, and if
+// an ack action fails the Close function is called on the underlying
+// acknowledger.
+// The default Acknowledger on the amq.Delivery is just an *amq.Channel.
+// By using the default Acknowledger here we ensure that this Acknowledger can
+// close the channel to restore the connection without closing the queueu or discarding messages.
+type Acknowledger struct {
+	Acknowledger amqp.Acknowledger
+	Handled      atomic.Bool
+}
+
+// NewAcknowledger returns the passed acknowledger as a Acknowledger.
+func NewAcknowledger(acknowledger amqp.Acknowledger) *Acknowledger {
+	return &Acknowledger{
 		Acknowledger: acknowledger,
-		conn:         ch,
 	}
 }
 
 // Ack passes the Ack down to the underlying Acknowledger.
-// Will close the underlying connection if ack fails.
-func (a *SafeAcknowledgeHandler) Ack(tag uint64, multiple bool) error {
-	if a.Handled {
+func (a *Acknowledger) Ack(tag uint64, multiple bool) error {
+	if !a.Handled.CompareAndSwap(false, true) {
 		return nil
 	}
-
-	a.Handled = true
 
 	err := a.Acknowledger.Ack(tag, multiple)
-	if err == nil {
-		return nil
-	}
-
-	slog.WarnContext(
-		context.Background(),
-		"error when acking",
-		"error",
-		err,
-	)
-
-	err = a.closeConnection()
 	if err != nil {
-		slog.ErrorContext(
-			context.Background(),
-			"could not close underlying connection",
-			"error",
-			err,
-		)
+		return errors.Join(err, a.close())
 	}
 
-	return err
+	return nil
 }
 
 // Nack passes the Nack down to the underlying Acknowledger.
-// Will close the underlying connection if nack fails.
-func (a *SafeAcknowledgeHandler) Nack(tag uint64, multiple, requeue bool) error {
-	if a.Handled {
+func (a *Acknowledger) Nack(tag uint64, multiple, requeue bool) error {
+	if !a.Handled.CompareAndSwap(false, true) {
 		return nil
 	}
-
-	a.Handled = true
 
 	err := a.Acknowledger.Nack(tag, multiple, requeue)
-	if err == nil {
-		return nil
-	}
-
-	slog.WarnContext(
-		context.Background(),
-		"error when nacking",
-		"error",
-		err,
-	)
-
-	err = a.closeConnection()
 	if err != nil {
-		slog.ErrorContext(
-			context.Background(),
-			"could not close underlying connection",
-			"error",
-			err,
-		)
+		return errors.Join(err, a.close())
 	}
 
-	return err
+	return nil
 }
 
 // Reject passes the Reject down to the underlying Acknowledger.
-// Will close the underlying connection if rejection fails.
-func (a *SafeAcknowledgeHandler) Reject(tag uint64, requeue bool) error {
-	if a.Handled {
+func (a *Acknowledger) Reject(tag uint64, requeue bool) error {
+	if !a.Handled.CompareAndSwap(false, true) {
 		return nil
 	}
-
-	a.Handled = true
 
 	err := a.Acknowledger.Reject(tag, requeue)
-	if err == nil {
+	if err != nil {
+		return errors.Join(err, a.close())
+	}
+
+	return nil
+}
+
+func (a *Acknowledger) close() error {
+	ackCloser, ok := a.Acknowledger.(closer)
+	if !ok {
 		return nil
 	}
 
-	slog.WarnContext(
-		context.Background(),
-		"error when rejecting",
-		"error",
-		err,
-	)
-
-	err = a.closeConnection()
-	if err != nil {
-		slog.ErrorContext(
-			context.Background(),
-			"could not close underlying connection",
-			"error",
-			err,
-		)
-	}
-
-	return err
-}
-
-func (a *SafeAcknowledgeHandler) closeConnection() error {
-	if a.conn == nil {
-		return errors.New("can't stop connection - no underlying connection set")
-	}
-
-	return a.conn.Close()
+	return ackCloser.Close()
 }

--- a/acknowledger_test.go
+++ b/acknowledger_test.go
@@ -4,68 +4,50 @@ import (
 	"errors"
 	"testing"
 
-	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAcknowledgeHandler(t *testing.T) {
-	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
-	require.NoError(t, err)
-
-	inputCh, err := conn.Channel()
-	require.NoError(t, err)
-
+func TestAwareAcknowledger(t *testing.T) {
 	var (
 		ma  = &MockAcknowledger{}
-		aac = NewSafeAcknowledgeHandler(ma, inputCh)
+		aac = NewAcknowledger(ma)
 	)
 
 	// 1
 	require.NoError(t, aac.Ack(1, false))
 
-	assert.True(t, aac.Handled, "delivery handled")
+	assert.True(t, aac.Handled.Load(), "delivery handled")
 	assert.Equal(t, 1, ma.Acks, "1 delivery processed")
 
-	// don't ack if already handled
-	require.NoError(t, aac.Ack(1, false))
-	assert.Equal(t, 1, ma.Acks, "1 delivery processed")
-
-	aac.Handled = false
+	aac.Handled.Store(false)
 
 	// 2
 	require.NoError(t, aac.Nack(2, false, false))
 
-	assert.True(t, aac.Handled, "delivery handled")
+	assert.True(t, aac.Handled.Load(), "delivery handled")
 	assert.Equal(t, 1, ma.Nacks, "1 delivery processed")
 
-	// don't nack if already handled
-	require.NoError(t, aac.Nack(2, false, false))
-	assert.Equal(t, 1, ma.Nacks, "1 delivery processed")
-
-	aac.Handled = false
+	aac.Handled.Store(false)
 
 	// 3
 	require.NoError(t, aac.Reject(3, false))
 
-	assert.True(t, aac.Handled, "delivery handled")
+	assert.True(t, aac.Handled.Load(), "delivery handled")
 	assert.Equal(t, 1, ma.Rejects, "1 delivery rejected")
 
-	// don't reject if already handled
-	require.NoError(t, aac.Reject(3, false))
-	assert.Equal(t, 1, ma.Rejects, "1 delivery processed")
+	// make sure the close function is called when ack fails
+	aac.Handled.Store(false)
 
-	aac.Handled = false
-
-	// connection has not been closed so far
-	assert.False(t, inputCh.IsClosed())
-
-	// close connection when ack fails
 	ma.OnAckFn = func() error {
 		return errors.New("ack error")
 	}
 
-	require.NoError(t, aac.Ack(1, false))
+	err := aac.Ack(1, false)
+	require.Error(t, err)
+	assert.Equal(t, "ack error", err.Error())
 
-	assert.True(t, inputCh.IsClosed())
+	assert.Equal(t, 1, ma.Closes)
+
+	aac.Handled.Store(false)
 }

--- a/acknowledger_test.go
+++ b/acknowledger_test.go
@@ -1,22 +1,34 @@
 package amqprpc
 
 import (
+	"errors"
 	"testing"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAwareAcknowledger(t *testing.T) {
+func TestAcknowledgeHandler(t *testing.T) {
+	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	require.NoError(t, err)
+
+	inputCh, err := conn.Channel()
+	require.NoError(t, err)
+
 	var (
 		ma  = &MockAcknowledger{}
-		aac = NewAwareAcknowledger(ma)
+		aac = NewSafeAcknowledgeHandler(ma, inputCh)
 	)
 
 	// 1
 	require.NoError(t, aac.Ack(1, false))
 
 	assert.True(t, aac.Handled, "delivery handled")
+	assert.Equal(t, 1, ma.Acks, "1 delivery processed")
+
+	// don't ack if already handled
+	require.NoError(t, aac.Ack(1, false))
 	assert.Equal(t, 1, ma.Acks, "1 delivery processed")
 
 	aac.Handled = false
@@ -27,6 +39,10 @@ func TestAwareAcknowledger(t *testing.T) {
 	assert.True(t, aac.Handled, "delivery handled")
 	assert.Equal(t, 1, ma.Nacks, "1 delivery processed")
 
+	// don't nack if already handled
+	require.NoError(t, aac.Nack(2, false, false))
+	assert.Equal(t, 1, ma.Nacks, "1 delivery processed")
+
 	aac.Handled = false
 
 	// 3
@@ -35,5 +51,21 @@ func TestAwareAcknowledger(t *testing.T) {
 	assert.True(t, aac.Handled, "delivery handled")
 	assert.Equal(t, 1, ma.Rejects, "1 delivery rejected")
 
+	// don't reject if already handled
+	require.NoError(t, aac.Reject(3, false))
+	assert.Equal(t, 1, ma.Rejects, "1 delivery processed")
+
 	aac.Handled = false
+
+	// connection has not been closed so far
+	assert.False(t, inputCh.IsClosed())
+
+	// close connection when ack fails
+	ma.OnAckFn = func() error {
+		return errors.New("ack error")
+	}
+
+	require.NoError(t, aac.Ack(1, false))
+
+	assert.True(t, inputCh.IsClosed())
 }

--- a/middleware/ack.go
+++ b/middleware/ack.go
@@ -9,60 +9,21 @@ import (
 	amqprpc "github.com/0x4b53/amqp-rpc/v5"
 )
 
-// OnErrFunc is the function that will be called when the middleware get an
-// error from `Ack`. The error and the delivery will be passed.
-type OnErrFunc func(err error, delivery amqp.Delivery)
-
-// OnAckErrorLog is a built-in function that will log the error if any is
-// returned from `Ack`.
-//
-//	middleware := AckDelivery(OnAckErrorLog(log.Printf))
-func OnAckErrorLog(logger *slog.Logger) OnErrFunc {
-	return func(err error, delivery amqp.Delivery) {
-		logger.Error("could not ack delivery (%s): %v\n",
-			slog.Any("error", err),
-			slog.String("correlation_id", delivery.CorrelationId),
-		)
-	}
-}
-
-// OnAckErrorSendOnChannel will first log the error and correlation ID and then
-// try to send on the passed channel. If no one is consuming on the passed
-// channel the middleware will not block but instead log a message about missing
-// channel consumers.
-func OnAckErrorSendOnChannel(logger *slog.Logger, ch chan struct{}) OnErrFunc {
-	logErr := OnAckErrorLog(logger)
-
-	return func(err error, delivery amqp.Delivery) {
-		logErr(err, delivery)
-
-		select {
-		case ch <- struct{}{}:
-		default:
-			logger.Error("ack middleware: could not send on channel, no one is consuming",
-				slog.String("correlation_id", delivery.CorrelationId),
-			)
-		}
-	}
-}
-
 // AckDelivery is a middleware that will acknowledge the delivery after the
-// handler has been executed. If the Ack fails the error and the `amqp.Delivery`
-// will be passed to the `OnErrFunc`.
-func AckDelivery(onErrFn OnErrFunc) amqprpc.ServerMiddlewareFunc {
+// handler has been executed.
+func AckDelivery() amqprpc.ServerMiddlewareFunc {
 	return func(next amqprpc.HandlerFunc) amqprpc.HandlerFunc {
 		return func(ctx context.Context, rw *amqprpc.ResponseWriter, d amqp.Delivery) {
-			acknowledger := amqprpc.NewAwareAcknowledger(d.Acknowledger)
-			d.Acknowledger = acknowledger
-
 			next(ctx, rw, d)
 
-			if acknowledger.Handled {
-				return
-			}
-
-			if err := d.Ack(false); err != nil {
-				onErrFn(err, d)
+			err := d.Ack(false)
+			if err != nil {
+				slog.ErrorContext(
+					context.Background(),
+					"acking message",
+					"correlation_id",
+					d.CorrelationId,
+				)
 			}
 		}
 	}

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -2,24 +2,19 @@ package middleware
 
 import (
 	"context"
-	"errors"
-	"log/slog"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/stretchr/testify/assert"
 
 	amqprpc "github.com/0x4b53/amqp-rpc/v5"
 )
 
 func TestAckDelivery(t *testing.T) {
 	tests := []struct {
-		handler          amqprpc.HandlerFunc
-		name             string
-		ackReturn        error
-		didSendOnChannel bool
+		handler   amqprpc.HandlerFunc
+		name      string
+		ackReturn error
 	}{
 		{
 			name:      "handler doesn't ack",
@@ -32,12 +27,6 @@ func TestAckDelivery(t *testing.T) {
 				_ = d.Ack(false)
 			},
 			ackReturn: nil,
-		},
-		{
-			name:             "handler fails to ack",
-			handler:          func(_ context.Context, _ *amqprpc.ResponseWriter, _ amqp.Delivery) {},
-			ackReturn:        errors.New("issue in the multiplexer"), //nolint:err113 // Just a test
-			didSendOnChannel: true,
 		},
 	}
 	for _, tt := range tests {
@@ -65,17 +54,12 @@ func TestAckDelivery(t *testing.T) {
 			// Block until ready.
 			<-isListening
 
-			handler := AckDelivery(OnAckErrorSendOnChannel(slog.Default(), ch))(tt.handler)
+			handler := AckDelivery()(tt.handler)
 
 			rw := amqprpc.ResponseWriter{Publishing: &amqp.Publishing{}}
 			d := amqp.Delivery{Acknowledger: acknowledger, CorrelationId: "id-1234"}
 
 			handler(context.Background(), &rw, d)
-
-			assert.Equal(t, 1, acknowledger.Acks)
-			assert.Eventually(t, func() bool {
-				return didSendOnCh.Load() == tt.didSendOnChannel
-			}, 2*time.Second, 100*time.Millisecond)
 		})
 	}
 }

--- a/middleware/ack_test.go
+++ b/middleware/ack_test.go
@@ -54,7 +54,7 @@ func TestAckDelivery(t *testing.T) {
 			// Block until ready.
 			<-isListening
 
-			handler := AckDelivery()(tt.handler)
+			handler := AckDelivery(false)(tt.handler)
 
 			rw := amqprpc.ResponseWriter{Publishing: &amqp.Publishing{}}
 			d := amqp.Delivery{Acknowledger: acknowledger, CorrelationId: "id-1234"}

--- a/server.go
+++ b/server.go
@@ -393,7 +393,7 @@ func (s *Server) consume(binding HandlerBinding, inputCh *amqp.Channel, wg *sync
 	// Attach the middlewares to the handler.
 	handler := ServerMiddlewareChain(binding.Handler, s.middlewares...)
 
-	go s.runHandler(handler, deliveries, queueName, wg, inputCh)
+	go s.runHandler(handler, deliveries, queueName, wg)
 
 	return consumerTag, nil
 }
@@ -403,7 +403,6 @@ func (s *Server) runHandler(
 	deliveries <-chan amqp.Delivery,
 	queueName string,
 	wg *sync.WaitGroup,
-	inputChannel *amqp.Channel,
 ) {
 	wg.Add(1)
 	defer wg.Done()
@@ -437,7 +436,7 @@ func (s *Server) runHandler(
 		ctx = ContextWithShutdownChan(ctx, s.stopChan)
 		ctx = ContextWithQueueName(ctx, queueName)
 
-		acknowledger := NewSafeAcknowledgeHandler(delivery.Acknowledger, inputChannel)
+		acknowledger := NewAcknowledger(delivery.Acknowledger)
 		delivery.Acknowledger = acknowledger
 
 		go func(delivery amqp.Delivery) {

--- a/testing.go
+++ b/testing.go
@@ -27,6 +27,7 @@ type MockAcknowledger struct {
 	Acks    int
 	Nacks   int
 	Rejects int
+	Closes  int
 	OnAckFn func() error
 }
 
@@ -50,6 +51,12 @@ func (ma *MockAcknowledger) Nack(_ uint64, _, _ bool) error {
 // Reject increases Rejects.
 func (ma *MockAcknowledger) Reject(_ uint64, _ bool) error {
 	ma.Rejects++
+	return nil
+}
+
+// Close increses Closes.
+func (ma *MockAcknowledger) Close() error {
+	ma.Closes++
 	return nil
 }
 


### PR DESCRIPTION
When closing the underlying connection on ack failure the connection will be restored if possible without closing queues and discarding messages.