### PR TITLE
Add server.IsConnected()

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,15 @@ services:
   rabbitmq:
     image: rabbitmq:4-management
     expose:
-     - "5672"
-     - "15672"
+      - "5672"
+      - "15672"
     ports:
       - "5672:5672"
       - "15672:15672"
     volumes:
       - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     healthcheck:
-      test: ['CMD-SHELL', 'rabbitmqctl status || exit 1']
+      test: ["CMD-SHELL", "rabbitmqctl status || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
IsConnected returns true when the server is connected and ready to receive and respond to messages on all queues. This is useful for healthchecks during rolling deployments.