### PR TITLE
Change logging level for unknown request confirmation

### DIFF
--- a/client.go
+++ b/client.go
@@ -603,12 +603,12 @@ func (c *Client) runConfirmsConsumer(confirms chan amqp.Confirmation, returns ch
 
 			request, ok := c.requestsMap.GetByDeliveryTag(confirm.DeliveryTag)
 			if !ok {
-				// This could happen if we stop waiting for requests to return due
-				// to a timeout. But since confirmations are normally very fast that
-				// would mean that something isn't quite right on the amqp server.
-				// Unfortunately there isn't any way of getting more information
-				// than the delivery tag from a confirmation.
-				c.logger.Error(
+				// The runRepliesConsumer may receive response deliveries
+				// before we receive the confirmation. In such cases, the
+				// request may have already been removed from the requestsMap.
+				// This is expected behavior, not an error.
+				// See: https://www.rabbitmq.com/docs/confirms#publisher-confirms-latency
+				c.logger.Debug(
 					"got confirmation of unknown request",
 					slog.Uint64("delivery_tag", confirm.DeliveryTag),
 				)


### PR DESCRIPTION
After the changes in v5.0.0 where the confirms and response handling where merged into one, we started to see "got confirmation of unknown request" errors. It turns out that this is completly expected since it is not guaranteed that the confirmation will be received before the response. In the previous implementation the request would always wait for the confirmation.

We can change the requestsMap to keep the request until confirmation arrives, even after the response has been received. But this is more overhead and not needed. During the 7 years of using this library in production, we have never seen an unknown confirmation.

See commit 1551ff6d35ff23d9a98102794c6d5ad79e0b3d39 for where we simplified the code and merged the confirms and response handling.

See https://www.rabbitmq.com/docs/confirms#publisher-confirms-latency for information about the confirmation latency.